### PR TITLE
Convert the minutes to a carbon object

### DIFF
--- a/src/Omniphx/Forrest/Providers/Laravel/LaravelCache.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/LaravelCache.php
@@ -35,7 +35,9 @@ class LaravelCache extends LaravelStorageProvider
         if ($this->storeForever) {
             return $this->cache->forever($this->path.$key, $value);
         } else {
-            return $this->cache->put($this->path.$key, $value, $this->minutes);
+            // RE: Laravel 5.0 docs, cache put accepts a Carbon object, so lets use now() + the configured minutes, so 5.8
+            //     can read it as seconds.
+            return $this->cache->put($this->path.$key, $value, now()->addMinutes($this->minutes));
         }
     }
 


### PR DESCRIPTION
Laravel 5.8 uses seconds now for cache ttl, so the best way to maintain backwards compatibility is to convert the minutes to a carbon object and pass that as the ttl.

It might be valuable to offer the option in the config to make the expire time in minutes or seconds, but for now this should ensure that cache isn't stored for only 20 seconds.