### PR TITLE
Add ability to pass query string to request

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -216,6 +216,12 @@ abstract class Client
         } else {
             unset($this->parameters['body']);
         }
+        
+        if (isset($this->options['query'])) {
+            $this->parameters['query'] = http_build_query($this->options['query']);
+        } else {
+            unset($this->parameters['query']);
+        }
 
         try {
             $response = $this->httpClient->request($this->options['method'], $this->url, $this->parameters);


### PR DESCRIPTION
SFDC requires query string of IDs for mass delete capability per docs here https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_delete.htm

I tried to work around it but the best solution was to add this logic to your `handleRequest` and ensure the `query` key is passed to the Guzzle request.